### PR TITLE
优化上传日志展示的路径打印格式

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function upload(receiver, to, data, release, content, file, callback) {
               time.grey + ' ' +
               subpath.replace(/^\//, '') +
               ' >> '.yellow.bold +
-              to + release
+              data['to']
           );
           callback();
         }


### PR DESCRIPTION
避免 `abc//def`形式的回显日志出现，以免误导。

to resolve https://github.com/fex-team/fis3-deploy-http-push/issues/13